### PR TITLE
Add publish command

### DIFF
--- a/linkfiles/.tool-versions
+++ b/linkfiles/.tool-versions
@@ -1,2 +1,0 @@
-pre-commit 3.3.3
-nodejs 20.13.1

--- a/tasks/node/Makefile
+++ b/tasks/node/Makefile
@@ -9,3 +9,7 @@ test::
 .PHONY: build
 build::
 	@npm run build
+
+.PHONY: publish
+publish::
+	@npm publish


### PR DESCRIPTION
- Removed .tool-versions because it will be part of the application repository where this component will be used.
- Added `publish` command